### PR TITLE
fix: rename conflicting template project name

### DIFF
--- a/bin/templates/basic/package.json
+++ b/bin/templates/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic",
+  "name": "basic_template",
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {

--- a/bin/templates/basic/package.json
+++ b/bin/templates/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic_template",
+  "name": "fast-express-template-basic",
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic",
+  "name": "fast-express-example-basic",
   "version": "1.0.0",
   "description": "A basic usage of fastexpress",
   "main": "server.js",

--- a/examples/complete/package.json
+++ b/examples/complete/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic",
+  "name": "fast-express-example-complete",
   "version": "1.0.0",
   "description": "A basic usage of fastexpress",
   "main": "server.js",


### PR DESCRIPTION
Just renames the project name in the basic template package.json